### PR TITLE
Revert "refactor: optimize sync on startup (#12)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.17.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.11.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/cc/ryanc/staticpages/StaticPagesPlugin.java
+++ b/src/main/java/cc/ryanc/staticpages/StaticPagesPlugin.java
@@ -1,13 +1,9 @@
 package cc.ryanc.staticpages;
 
-import static run.halo.app.extension.index.IndexAttributeFactory.simpleAttribute;
-
 import cc.ryanc.staticpages.extensions.Project;
-import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
 import run.halo.app.extension.Scheme;
 import run.halo.app.extension.SchemeManager;
-import run.halo.app.extension.index.IndexSpec;
 import run.halo.app.plugin.BasePlugin;
 import run.halo.app.plugin.PluginContext;
 
@@ -22,19 +18,7 @@ public class StaticPagesPlugin extends BasePlugin {
 
     @Override
     public void start() {
-        schemeManager.register(Project.class, indexSpecs -> {
-            indexSpecs.add(new IndexSpec()
-                .setName(Project.SYNC_ON_STARTUP_INDEX)
-                .setIndexFunc(simpleAttribute(Project.class, project -> {
-                    var version = project.getMetadata().getVersion();
-                    var observedVersion = project.getStatus().getObservedVersion();
-                    if (observedVersion == null || observedVersion < version) {
-                        return BooleanUtils.TRUE;
-                    }
-                    // do not care about the false case so return null to avoid indexing
-                    return null;
-                })));
-        });
+        schemeManager.register(Project.class);
     }
 
     @Override

--- a/src/main/java/cc/ryanc/staticpages/extensions/Project.java
+++ b/src/main/java/cc/ryanc/staticpages/extensions/Project.java
@@ -7,8 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import org.springframework.lang.NonNull;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
@@ -17,18 +15,9 @@ import run.halo.app.extension.GVK;
 @GVK(group = "staticpage.halo.run", version = "v1alpha1", kind = "Project",
     plural = "projects", singular = "project")
 public class Project extends AbstractExtension {
-    public static final String SYNC_ON_STARTUP_INDEX = "sync-on-startup";
 
     @Schema(requiredMode = REQUIRED)
     private Spec spec;
-
-    @Getter(onMethod_ = @NonNull)
-    @Schema(requiredMode = NOT_REQUIRED)
-    private Status status = new Status();
-
-    public void setStatus(Status status) {
-        this.status = (status == null ? new Status() : status);
-    }
 
     @Data
     @Schema(name = "ProjectSpec")
@@ -55,11 +44,5 @@ public class Project extends AbstractExtension {
 
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String target;
-    }
-
-    @Data
-    @Schema(name = "ProjectStatus")
-    public static class Status {
-        private Long observedVersion;
     }
 }

--- a/src/main/java/cc/ryanc/staticpages/extensions/ProjectReconciler.java
+++ b/src/main/java/cc/ryanc/staticpages/extensions/ProjectReconciler.java
@@ -2,9 +2,6 @@ package cc.ryanc.staticpages.extensions;
 
 import static run.halo.app.extension.ExtensionUtil.addFinalizers;
 import static run.halo.app.extension.ExtensionUtil.removeFinalizers;
-import static run.halo.app.extension.index.query.QueryFactory.and;
-import static run.halo.app.extension.index.query.QueryFactory.equal;
-import static run.halo.app.extension.index.query.QueryFactory.isNull;
 
 import cc.ryanc.staticpages.service.PageProjectService;
 import cc.ryanc.staticpages.service.ProjectRewriteRules;
@@ -13,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ExtensionUtil;
-import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.controller.Controller;
 import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
@@ -41,11 +37,6 @@ public class ProjectReconciler implements Reconciler<Reconciler.Request> {
                 }
                 addFinalizers(project.getMetadata(), Set.of(FINALIZER));
                 projectRewriteRules.updateRules(project);
-
-                // version + 1 is required to truly equal version
-                // as a version will be incremented after the update
-                project.getStatus().setObservedVersion(project.getMetadata().getVersion() + 1);
-
                 client.update(project);
             });
         return Result.doNotRetry();
@@ -55,13 +46,6 @@ public class ProjectReconciler implements Reconciler<Reconciler.Request> {
     public Controller setupWith(ControllerBuilder builder) {
         return builder
             .extension(new Project())
-            .syncAllListOptions(ListOptions.builder()
-                .fieldQuery(and(
-                    isNull("metadata.deletionTimestamp"),
-                    equal(Project.SYNC_ON_STARTUP_INDEX, "true")
-                ))
-                .build()
-            )
             .build();
     }
 }


### PR DESCRIPTION
This reverts commit 78c7fc3523f2ac99d46ce87d842d2e35c2353e7e.

这里需要在启动时构建重写规则，原本添加这个改动之后需要在停止时将规则持久化并在启动时将规则查询出来到保存到内存，但是考虑到这样修改可能复杂性高而且不划算，因此撤销这个对 reconciler 的改动来修复重写规则不生效的问题